### PR TITLE
Fix robot_options & pabot_options

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,5 @@ Available configurations in with block:
 | screen_color_depth       | 24            | Color depth of the virtual screen                      |
 | screen_height            | 1080          | Height of the virtual screen                           |
 | screen_width             | 1920          | Width of the virtual screen                            |
+| robot_tests_dir          | 'robot_tests' | Location of tests inside repository                    |
+| robot_reports_dir        | 'reports'     | Location of report output from test execution          |

--- a/test.sh
+++ b/test.sh
@@ -6,8 +6,8 @@ sudo mkdir $REPORTS_DIR && sudo chmod 777 $REPORTS_DIR
 docker run --shm-size=$ALLOWED_SHARED_MEMORY \
   -e BROWSER=$BROWSER \
   -e ROBOT_THREADS=$ROBOT_THREADS \
-  -e PABOT_OPTIONS=$PABOT_OPTIONS \
-  -e ROBOT_OPTIONS=$ROBOT_OPTIONS \
+  -e PABOT_OPTIONS="$PABOT_OPTIONS" \
+  -e ROBOT_OPTIONS="$ROBOT_OPTIONS" \
   -v $REPORTS_DIR:/opt/robotframework/reports:Z \
   -v $TESTS_DIR:/opt/robotframework/tests:Z \
   --user $(id -u):$(id -g) \


### PR DESCRIPTION
Values used in robot_options & pabot_options needs to be quoted as without the quotes Docker will fail to run.

Closes #7 