### PR TITLE
make the docker image configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,15 +35,16 @@ Run with firefox and in parallel:
 
 Available configurations in with block:
 
-| Name                     | Default       | Description                                            |
-| ------------------------ | ------------- | ------------------------------------------------------ |
-| allowed_shared_memory    | '1g'          | How much container can use shared memory               |
-| browser                  | 'chrome'      | Available options chrome / firefox                     |
-| robot_threads            | 1             | Change this > 1 if you want to run tests in parallel   |
-| pabot_options            | ''            | These are only used if robot_threads > 1               |
-| robot_options            | ''            | Pass extra settings for robot command                  |
-| screen_color_depth       | 24            | Color depth of the virtual screen                      |
-| screen_height            | 1080          | Height of the virtual screen                           |
-| screen_width             | 1920          | Width of the virtual screen                            |
-| robot_tests_dir          | 'robot_tests' | Location of tests inside repository                    |
-| robot_reports_dir        | 'reports'     | Location of report output from test execution          |
+| Name                     | Default                             | Description                                          |
+| ------------------------ | ----------------------------------- | ---------------------------------------------------- |
+| allowed_shared_memory    | '1g'                                | How much container can use shared memory             |
+| browser                  | 'chrome'                            | Available options chrome / firefox                   |
+| robot_threads            | 1                                   | Change this > 1 if you want to run tests in parallel |
+| pabot_options            | ''                                  | These are only used if robot_threads > 1             |
+| robot_options            | ''                                  | Pass extra settings for robot command                |
+| screen_color_depth       | 24                                  | Color depth of the virtual screen                    |
+| screen_height            | 1080                                | Height of the virtual screen                         |
+| screen_width             | 1920                                | Width of the virtual screen                          |
+| robot_tests_dir          | 'robot_tests'                       | Location of tests inside repository                  |
+| robot_reports_dir        | 'reports'                           | Location of report output from test execution        |
+| robot_runner_image       | 'ppodgorsek/robot-framework:latest' | Docker image which will be used to execute the tests |

--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,11 @@ inputs:
     description: 'Where will the report from test be saved'
     required: true
     default: 'reports'
+  robot_runner_image:
+    description: 'The docker image which will be used to execute the tests'
+    required: true
+    default: 'ppodgorsek/robot-framework:latest'
+
 
 runs:
   using: 'composite'
@@ -58,3 +63,4 @@ runs:
         SCREEN_WIDTH: ${{ inputs.screen_width }}
         ROBOT_TESTS_DIR: ${{ inputs.robot_tests_dir }}
         ROBOT_REPORTS_DIR: ${{ inputs.robot_reports_dir }}
+        ROBOT_RUNNER_IMAGE: ${{ inputs.robot_runner_image }}

--- a/test.sh
+++ b/test.sh
@@ -11,4 +11,4 @@ docker run --shm-size=$ALLOWED_SHARED_MEMORY \
   -v $REPORTS_DIR:/opt/robotframework/reports:Z \
   -v $TESTS_DIR:/opt/robotframework/tests:Z \
   --user $(id -u):$(id -g) \
-  ppodgorsek/robot-framework:latest
+  $ROBOT_RUNNER_IMAGE


### PR DESCRIPTION
This PR adds the option to configure the image for executing the tests. 
By default it will continue to use `ppodgorsek/robot-framework:latest`, but you can now configure it to be a different image by setting the option `robot_runner_image`.

To test this PR I used this github action: https://github.com/score-spec/score-compose/blob/a538d7fa20ca8f2658a55cf5c964f8de980d7a8a/.github/workflows/release.yaml#L46
which is using an alternative image to run the robot tests.
Here is the successful run of the action: https://github.com/score-spec/score-compose/actions/runs/3549897377/jobs/5962766822#step:9:83
