### PR TITLE
Mount resources directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Run with chrome:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Robot Framework
-        uses: joonvena/robotframework-docker-action@v1.0
+        uses: felipeholek/robotframework-docker-action@master
 ```
 
 Run with firefox and in parallel:
@@ -30,7 +30,7 @@ Run with firefox and in parallel:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Robot Framework
-        uses: joonvena/robotframework-docker-action@v1.0
+        uses: felipeholek/robotframework-docker-action@master
         with:
           browser: 'firefox'
           robot_threads: 2

--- a/README.md
+++ b/README.md
@@ -50,4 +50,5 @@ Available configurations in with block:
 | screen_width             | 1920                                | Width of the virtual screen                          |
 | robot_tests_dir          | 'robot_tests'                       | Location of tests inside repository                  |
 | robot_reports_dir        | 'reports'                           | Location of report output from test execution        |
+| robot_resources_dir      | 'resources'                         | Location of resources inside repository              |
 | robot_runner_image       | 'ppodgorsek/robot-framework:latest' | Docker image which will be used to execute the tests |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-> **Note**
-> This repo is forked from [joonvena/robotframework-docker-action](https://github.com/joonvena/robotframework-docker-action)
-
 # Robot Framework Docker Action
 
 This action runs Robot Framework tests using [ppodgorsek](https://github.com/ppodgorsek/docker-robot-framework) image.
@@ -17,7 +14,7 @@ Run with chrome:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Robot Framework
-        uses: felipeholek/robotframework-docker-action@master
+        uses: joonvena/robotframework-docker-action@v1.1
 ```
 
 Run with firefox and in parallel:
@@ -30,7 +27,7 @@ Run with firefox and in parallel:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Robot Framework
-        uses: felipeholek/robotframework-docker-action@master
+        uses: joonvena/robotframework-docker-action@v1.1
         with:
           browser: 'firefox'
           robot_threads: 2

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> **Note**
+> This repo is forked from [joonvena/robotframework-docker-action](https://github.com/joonvena/robotframework-docker-action)
+
 # Robot Framework Docker Action
 
 This action runs Robot Framework tests using [ppodgorsek](https://github.com/ppodgorsek/docker-robot-framework) image.

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,10 @@ inputs:
     description: 'Directory where Robot tests are located in the repository'
     required: true
     default: 'robot_tests'
+  robot_resources_dir:
+    description: 'Directory where Robot resources are located in the repository'
+    required: true
+    default: 'resources'
   robot_reports_dir:
     description: 'Where will the report from test be saved'
     required: true
@@ -63,4 +67,5 @@ runs:
         SCREEN_WIDTH: ${{ inputs.screen_width }}
         ROBOT_TESTS_DIR: ${{ inputs.robot_tests_dir }}
         ROBOT_REPORTS_DIR: ${{ inputs.robot_reports_dir }}
+        ROBOT_RESOURCES_DIR: ${{ inputs.robot_resources_dir }}
         ROBOT_RUNNER_IMAGE: ${{ inputs.robot_runner_image }}

--- a/test.sh
+++ b/test.sh
@@ -1,6 +1,7 @@
 # Create reports folder
 REPORTS_DIR=$(pwd)/$ROBOT_REPORTS_DIR
 TESTS_DIR=$(pwd)/$ROBOT_TESTS_DIR
+RESOURCES_DIR=$(pwd)/$ROBOT_RESOURCES_DIR
 sudo mkdir $REPORTS_DIR && sudo chmod 777 $REPORTS_DIR
 
 docker run --shm-size=$ALLOWED_SHARED_MEMORY \
@@ -9,6 +10,7 @@ docker run --shm-size=$ALLOWED_SHARED_MEMORY \
   -e PABOT_OPTIONS="$PABOT_OPTIONS" \
   -e ROBOT_OPTIONS="$ROBOT_OPTIONS" \
   -v $REPORTS_DIR:/opt/robotframework/reports:Z \
+  -v $RESOURCES_DIR:/opt/robotframework/resources:Z \
   -v $TESTS_DIR:/opt/robotframework/tests:Z \
   --user $(id -u):$(id -g) \
   $ROBOT_RUNNER_IMAGE


### PR DESCRIPTION
This PR adds a new input "robot_resources_dir" (defaults to 'resources') and mounts it to /opt/robotframework/resources

This adheres to robot framework's [official documentation](https://docs.robotframework.org/docs/examples/project_structure#examples) on project structure.

I've tested this implementation running a action on a private repo and I can confirm it correctly mounts the folder, as this has supressed the "Resource file does not exist." errors I was running into.

